### PR TITLE
Use c_char for InstanceProcAddr

### DIFF
--- a/src/xr_session.rs
+++ b/src/xr_session.rs
@@ -22,7 +22,7 @@ impl VulkanContext {
 
         type InstanceProcAddr = unsafe extern "system" fn(
             *const std::ffi::c_void,
-            *const i8,
+            *const std::ffi::c_char,
         )
             -> Option<unsafe extern "system" fn()>;
 


### PR DESCRIPTION
This fixes the build for aarch64/arm64. Noticed in
https://github.com/nix-community/nixpkgs-xr/pull/689
